### PR TITLE
replaces: unused public by private for bukkit events

### DIFF
--- a/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
+++ b/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
@@ -40,7 +40,7 @@ public final class FastInvManager {
         Bukkit.getPluginManager().registerEvents(new Listener() {
 
             @EventHandler(priority = EventPriority.LOW)
-            public void onInventoryClick(InventoryClickEvent e) {
+            private void onInventoryClick(InventoryClickEvent e) {
                 if (e.getInventory().getHolder() instanceof FastInv && e.getClickedInventory() != null) {
                     FastInv inv = (FastInv) e.getInventory().getHolder();
 
@@ -57,7 +57,7 @@ public final class FastInvManager {
             }
 
             @EventHandler
-            public void onInventoryOpen(InventoryOpenEvent e) {
+            private void onInventoryOpen(InventoryOpenEvent e) {
                 if (e.getInventory().getHolder() instanceof FastInv) {
                     FastInv inv = (FastInv) e.getInventory().getHolder();
 
@@ -66,7 +66,7 @@ public final class FastInvManager {
             }
 
             @EventHandler
-            public void onInventoryClose(InventoryCloseEvent e) {
+            private void onInventoryClose(InventoryCloseEvent e) {
                 if (e.getInventory().getHolder() instanceof FastInv) {
                     FastInv inv = (FastInv) e.getInventory().getHolder();
 
@@ -77,7 +77,7 @@ public final class FastInvManager {
             }
 
             @EventHandler
-            public void onPluginDisable(PluginDisableEvent e) {
+            private void onPluginDisable(PluginDisableEvent e) {
                 if (e.getPlugin() == plugin) {
                     closeAll();
 


### PR DESCRIPTION
Since it is not necessary to use public methods to make bukkit events and these methods should not be called by API users, I have replaced public fields with private ones (for bukkit events).