### PR TITLE
Fix FastInvManager.closeAll() not working on 1.20.6 >

### DIFF
--- a/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
+++ b/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
@@ -33,7 +33,6 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.server.PluginDisableEvent;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.InventoryView;
 import org.bukkit.plugin.Plugin;
 
@@ -82,8 +81,7 @@ public final class FastInvManager {
             getTopInventoryMethod.setAccessible(true);
             for (Player p : Bukkit.getOnlinePlayers()) {
                 Inventory top = (Inventory) getTopInventoryMethod.invoke(p.getOpenInventory());
-                InventoryHolder holder = top.getHolder();
-                if (holder instanceof FastInv)
+                if (top.getHolder() instanceof FastInv)
                     p.closeInventory();
             }
         } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {

--- a/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
+++ b/src/main/java/fr/mrmicky/fastinv/FastInvManager.java
@@ -32,15 +32,10 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.server.PluginDisableEvent;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryView;
 import org.bukkit.plugin.Plugin;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 
 /**
  * Manager for FastInv listeners.
@@ -70,23 +65,6 @@ public final class FastInvManager {
         }
 
         Bukkit.getPluginManager().registerEvents(new InventoryListener(plugin), plugin);
-    }
-
-    /**
-     * Close all open FastInv inventories.
-     */
-    public static void closeAll() {
-        try {
-            Method getTopInventoryMethod = InventoryView.class.getDeclaredMethod("getTopInventory");
-            getTopInventoryMethod.setAccessible(true);
-            for (Player p : Bukkit.getOnlinePlayers()) {
-                Inventory top = (Inventory) getTopInventoryMethod.invoke(p.getOpenInventory());
-                if (top.getHolder() instanceof FastInv)
-                    p.closeInventory();
-            }
-        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-            Bukkit.getLogger().log(Level.WARNING, "Failed to close all FastInv inventories", e);
-        }
     }
 
     public static final class InventoryListener implements Listener {
@@ -154,8 +132,6 @@ public final class FastInvManager {
         @EventHandler
         public void onPluginDisable(PluginDisableEvent e) {
             if (e.getPlugin() == this.plugin) {
-                closeAll();
-
                 REGISTERED.set(false);
             }
         }


### PR DESCRIPTION
The method has gotten uglier, but I tested and it worked on 1.21.1. It's safe to assume it'll work on all versions.